### PR TITLE
GalleryActivity crashes on launch - IllegalArgumentException: No config chosen

### DIFF
--- a/GLWallpaperTest/src/net/markguerra/android/glwallpapertest/GalleryActivity.java
+++ b/GLWallpaperTest/src/net/markguerra/android/glwallpapertest/GalleryActivity.java
@@ -16,6 +16,15 @@ public class GalleryActivity extends Activity {
 		//Instantiate OpenGL drawing surface and hold a reference
 		ViewGroup container = (ViewGroup)findViewById(R.id.container);
 		glView = new GLSurfaceView(this);
+
+		int redSize = 8;
+		int greenSize = 8;
+		int blueSize = 8;
+		int alphaSize = 8;
+		int depthSize = 16;
+		int stencilSize = 0;
+		glView.setEGLConfigChooser(redSize, greenSize, blueSize, alphaSize, depthSize, stencilSize);
+
 		MyRenderer renderer = new MyRenderer();
 		glView.setRenderer(renderer);
 


### PR DESCRIPTION
If you try to launch GLWS using the included GalleryActivity, the application crashes on launch. Here is the logcat output.

```
03-09 14:31:02.927: E/AndroidRuntime(986): java.lang.IllegalArgumentException: No config chosen
03-09 14:31:02.927: E/AndroidRuntime(986):  at android.opengl.GLSurfaceView$BaseConfigChooser.chooseConfig(GLSurfaceView.java:874)
03-09 14:31:02.927: E/AndroidRuntime(986):  at android.opengl.GLSurfaceView$EglHelper.start(GLSurfaceView.java:1024)
03-09 14:31:02.927: E/AndroidRuntime(986):  at android.opengl.GLSurfaceView$GLThread.guardedRun(GLSurfaceView.java:1401)
03-09 14:31:02.927: E/AndroidRuntime(986):  at android.opengl.GLSurfaceView$GLThread.run(GLSurfaceView.java:1240)
```
